### PR TITLE
Adds support for all the hidden folders that adobe creates 

### DIFF
--- a/reveal
+++ b/reveal
@@ -11,11 +11,10 @@ select dce in "Dry-Run" "Copy" "Exit"; do
     esac
 done
 
-cd $HOME/Library/Application\ Support/Adobe/CoreSync/plugins/livetype/.r/
-
+cd $HOME/Library/Application\ Support/Adobe/CoreSync/plugins/livetype/
 # grab all otf dot files (adjust to your needs)
-for file in .*.otf
-do  
+find . -type f -iname "*.otf" | while read file
+do
   # the "Postscript name:" does not contain spaces. good for file names.
   fontName=`otfinfo --info ${file} | fgrep "PostScript name:" | grep -oE "[^ ]+$"`
   


### PR DESCRIPTION
Adds support for all the folders in side `.../livetype/*` that adobe creates. As mentioned on issue #16  by @davim00

Tested with obfuscated fonts in folder `.w`

<img width="607" alt="image" src="https://github.com/kalaschnik/adobe-fonts-revealer/assets/5617032/48221237-dbdf-4a54-bdc9-66b5b7db33b5">
